### PR TITLE
Add trello scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can also search for non-uploaded submission for artists. How well this works
 * <img src="public/icons/7-pixiv.png" width="16px" height="16px"> Pixiv
 * <img src="public/icons/10-reddit.png" width="16px" height="16px"> Reddit
 * <img src="public/icons/3-sofurry.png" width="16px" height="16px"> Sofurry
+* <img src="public/icons/45-trello.png" width="16px" height="16px"> Trello
 * <img src="public/icons/9-tumblr.png" width="16px" height="16px"> Tumblr ([see notes](#tumblr))
 * <img src="public/icons/0-twitter.png" width="16px" height="16px"> Twitter
 * <img src="public/icons/8-weasyl.png" width="16px" height="16px"> Weasyl

--- a/app/logical/scraper/trello.rb
+++ b/app/logical/scraper/trello.rb
@@ -1,0 +1,61 @@
+module Scraper
+  # https://developer.atlassian.com/cloud/trello/rest
+  class Trello < Base
+    STATE = :before
+    OPTIONAL_CONFIG_KEYS = %i[trello_key trello_token].freeze
+
+    def initialize(artist_url)
+      super
+      @before = nil
+    end
+
+    def fetch_next_batch
+      url = "https://api.trello.com/1/boards/#{api_identifier}/cards"
+      json = fetch_json(url,
+        params: {
+          attachments: true,
+          attachment_fields: "id,date,url",
+          fields: "id,desc,shortLink,name",
+          limit: 1000,
+          sort: "-id",
+        }.tap { |h| h[:before] = @before if @before }
+         .tap { |h| h[:key] = Config.trello_key if Config.trello_key }
+         .tap { |h| h[:token] = Config.trello_token if Config.trello_token },
+      )
+      @before = json.min_by { |c| c["id"][0..7].to_i(16) }.try(:[], "id")
+      end_reached if json.length < 1000
+      json.reject { |c| c["attachments"].empty? }
+    end
+
+    def to_submission(submission)
+      s = Submission.new
+      s.identifier = submission["shortLink"]
+      s.title = submission["name"]
+      s.description = submission["desc"]
+      s.created_at = Time.zone.at(submission["id"][0..7].to_i(16)).to_datetime
+
+      submission["attachments"].each do |entry|
+        s.add_file({
+          url: entry["url"],
+          created_at: DateTime.parse(entry["date"]),
+          identifier: entry["id"],
+        })
+      end
+      s
+    end
+
+    def fetch_api_identifier
+      url = "https://trello.com/b/#{url_identifier}.json"
+      json = fetch_json(url, params: {
+        actions: "none",
+        cards: "none",
+        fields: "id",
+        labels: "none",
+        lists: "none",
+      }
+       .tap { |h| h[:key] = Config.trello_key if Config.trello_key }
+       .tap { |h| h[:token] = Config.trello_token if Config.trello_token })
+      json["id"]
+    end
+  end
+end

--- a/app/logical/scraper/trello.rb
+++ b/app/logical/scraper/trello.rb
@@ -62,6 +62,7 @@ module Scraper
 
     private
 
+    # https://support.atlassian.com/trello/docs/getting-the-time-a-card-or-board-was-created/
     def to_unix(id)
       id[0..7].to_i(16)
     end

--- a/app/logical/scraper/trello.rb
+++ b/app/logical/scraper/trello.rb
@@ -32,7 +32,7 @@ module Scraper
       s.identifier = submission["shortLink"]
       s.title = submission["name"]
       s.description = submission["desc"]
-      s.created_at = Time.zone.at(submission["id"][0..7].to_i(16)).to_datetime
+      s.created_at = DateTime.strptime(submission["id"][0..7].to_i(16).to_s, "%s")
 
       submission["attachments"].each do |entry|
         s.add_file({

--- a/app/logical/sites/definitions/trello.yml
+++ b/app/logical/sites/definitions/trello.yml
@@ -1,4 +1,4 @@
-type: SimpleDefinition
+type: ScraperDefinition
 enum_value: trello
 display_name: Trello
 homepage: https://trello.com

--- a/app/views/config/info/_trello.html.erb
+++ b/app/views/config/info/_trello.html.erb
@@ -1,0 +1,2 @@
+<%# locals: () -%>
+Create a powerup at <a href="https://trello.com/power-ups/admin">https://trello.com/power-ups/admin</a>, then authorize a token for your own account.

--- a/config/foxtrove.yml
+++ b/config/foxtrove.yml
@@ -46,3 +46,5 @@ artfight_user:
 artfight_pass:
 commishes_user:
 commishes_pass:
+trello_key:
+trello_token:

--- a/test/logical/scraper/live_test.rb
+++ b/test/logical/scraper/live_test.rb
@@ -107,6 +107,10 @@ module Scraper
         assert_scraper(Scraper::Sofurry, "zummeng", "373836")
       end
 
+      test "trello" do
+        assert_scraper(Scraper::Trello, "2fDaPKHy/codys-comms", "63c0a4fd52d78f036e355512")
+      end
+
       test "tumblr" do
         assert_scraper(Scraper::Tumblr, "yuumei-art", "t:DlrWdEaIry0XVtS7NBwpHQ", skip_files: true)
       end


### PR DESCRIPTION
A full scraper for attachments on trello cards
Authentication is not required for api access

docs for cards: https://developer.atlassian.com/cloud/trello/rest/api-group-boards/#api-boards-id-cards-get
I forget where I saw that you can append .json onto the board url to get the board's actual id, but it follows the same usage as https://developer.atlassian.com/cloud/trello/rest/api-group-boards/#api-boards-id-get

Also, the first 8 characters of ids are a hex encoded timestamp