### PR TITLE
Don't discard submissions from users with display names

### DIFF
--- a/app/logical/scraper/furaffinity.rb
+++ b/app/logical/scraper/furaffinity.rb
@@ -79,8 +79,8 @@ module Scraper
       )
       # Searching for "@lower scale" returns results from blue-scale
       relevant_submissions = html.css("#browse-search figure").select do |element|
-        # Remove _ from displayname, https://www.furaffinity.net/user/thesecretcave/ => The_Secret_Cave
-        element.css("figcaption a")[1].content.downcase.delete("_") == url_identifier.downcase
+        # Display names can now be arbitrary text, so take the identifier from the href.
+        element.css("figcaption a")[1]["href"].split("/")[2] == url_identifier.downcase
       end
       relevant_submissions.map do |element|
         element.attributes["id"].value.split("-")[1]


### PR DESCRIPTION
Prevent submissions from users with display names from being discarded by the scraper by using the href instead of the caption.

Display names were launched for subscribers on 3 March ([source](https://www.furaffinity.net/journal/11085097/)), so anybody affected by this change might want to roll back their last scraped dates for FA to avoid any missed submissions.