### PR TITLE
Update date format for Fur Affinity scraper

### DIFF
--- a/app/logical/scraper/furaffinity.rb
+++ b/app/logical/scraper/furaffinity.rb
@@ -95,10 +95,10 @@ module Scraper
       element = html.css(".submission-id-container .popup_date").first
       begin
         # Full date format
-        DateTime.strptime(element.content.strip, "%b %d, %Y %I:%M %p")
+        DateTime.strptime(element.content.strip, "%B %d, %Y, %H:%M:%S")
       rescue ArgumentError
         # Fuzzy date format
-        DateTime.strptime(element.attribute("title").content.strip, "%b %d, %Y %I:%M %p")
+        DateTime.strptime(element.attribute("title").content.strip, "%B %d, %Y, %H:%M:%S")
       end
     end
 


### PR DESCRIPTION
Apparently FA changed their date format, this PR updates it for the new one.

Old format: `Aug 23, 2025 05:10 AM`
New format: `September 16, 2025, 20:49:05`